### PR TITLE
No multitable delete

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,21 @@ This requires table names in filters to match table names in values, which is no
 
 Now `update()` produces a single query and (in above example) subsequently a database error, when the columns cannot be found on the table. Usage has to be replaced with individual objects.
 
+
+### DELETE only affects one table per criteria
+*Affects manual use of Criteria::delete() or TableMap::doDelete()-  does not affect updates through Propel*
+
+Same as with `Criteria::update()` above, delete can only affect one table per object.
+```php
+// Causes exception now
+$c = new Criteria();
+$c->add(BookTableMap::COL_ID, $hp->getId());
+$c->add(AuthorTableMap::COL_ID, $hp->getAuthorId());
+$c->add(PublisherTableMap::COL_ID, $hp->getPublisherId());
+BookTableMap::doDelete($c);
+```
+Use model objects (`$hp->delete()`) or query (`BookQuery::create()->filterById($hp->getId())->delete()`) to delete, one for each table.
+
 ### Forcing table alias in UPDATE on Sqlite
 *Affects users that force table alias on a DBMS that does not allow table aliases in UPDATE*
 
@@ -162,7 +177,6 @@ A full list of deprecated methods can be found in [#28](https://github.com/mring
 ## Outlook
 
 Some things I would like to do when I find the time:
-- `Criteria::delete()` should not delete on several tables (similar as `Criteria::update()` above).
 - Delay resolving of column names until query is created.
 - Automatically build subclasses of ObjectCollection for each model class, which provide typed entries to `ObjectCollection::populateRelation()` for model relations (i.e. `AuthorQuery::create()->findObjects()->populateBooks()`).
 - Get prepared statement parameters without building filters for QueryCache behavior.

--- a/src/Propel/Generator/Builder/Om/TableMapBuilder.php
+++ b/src/Propel/Generator/Builder/Om/TableMapBuilder.php
@@ -1433,6 +1433,8 @@ class " . $this->getUnqualifiedClassName() . " extends TableMap
         $table = $this->getTable();
         $script .= "
     /**
+     * @deprecated Delete via model or {$this->getQueryClassName()}.
+     *
      * Performs a DELETE on the database, given a " . $this->getObjectClassName() . " or Criteria object OR a primary key value.
      *
      * @param mixed \$values Criteria or " . $this->getObjectClassName() . " object or primary key or array of primary keys
@@ -1445,6 +1447,8 @@ class " . $this->getUnqualifiedClassName() . " extends TableMap
      */
      public static function doDelete(\$values, ?ConnectionInterface \$con = null): int
      {
+        trigger_deprecation('Propel', '2.0', 'TableMap::doDelete() should not be used anymore, delete via model or {$this->getQueryClassName()}');
+
         if (null === \$con) {
             \$con = Propel::getServiceContainer()->getWriteConnection(" . $this->getTableMapClass() . "::DATABASE_NAME);
         }

--- a/tests/Propel/Tests/BookstoreTest.php
+++ b/tests/Propel/Tests/BookstoreTest.php
@@ -318,15 +318,9 @@ class BookstoreTest extends BookstoreEmptyTestBase
         $this->assertNotNull($hp, 'Could find just-created book');
 
         // Attempting to delete [multi-table] by found pk
-        $c = new Criteria();
-        $c->add(BookTableMap::COL_ID, $hp->getId());
-        // The only way for cascading to work currently
-        // is to specify the author_id and publisher_id (i.e. the fkeys
-        // have to be in the criteria).
-        $c->add(AuthorTableMap::COL_ID, $hp->getAuthor()->getId());
-        $c->add(PublisherTableMap::COL_ID, $hp->getPublisher()->getId());
-        $c->setSingleRecord(true);
-        BookTableMap::doDelete($c);
+        $hp->delete();
+        $hp->getAuthor()->delete();
+        $hp->getPublisher()->delete();
 
         // Checking to make sure correct records were removed.
         $this->assertEquals(3, AuthorQuery::create()->count(), 'Correct records were removed from author table');
@@ -354,10 +348,6 @@ class BookstoreTest extends BookstoreEmptyTestBase
         PublisherTableMap::doDelete($penguin_id);
         $vintage->delete();
 
-        // These have to be deleted manually also since we have onDelete
-        // set to SETNULL in the foreign keys in book. Is this correct?
-        $rowling->delete();
-        $scholastic->delete();
         $blc1->delete();
         $blc2->delete();
 
@@ -667,15 +657,9 @@ class BookstoreTest extends BookstoreEmptyTestBase
         $this->assertNotNull($hp, 'Could find just-created book');
 
         // Attempting to delete [multi-table] by found pk
-        $c = new Criteria();
-        $c->add(BookTableMap::COL_ID, $hp->getId());
-        // The only way for cascading to work currently
-        // is to specify the author_id and publisher_id (i.e. the fkeys
-        // have to be in the criteria).
-        $c->add(AuthorTableMap::COL_ID, $hp->getAuthor()->getId());
-        $c->add(PublisherTableMap::COL_ID, $hp->getPublisher()->getId());
-        $c->setSingleRecord(true);
-        BookTableMap::doDelete($c);
+        $hp->delete();
+        $hp->getAuthor()->delete();
+        $hp->getPublisher()->delete();
 
         // Checking to make sure correct records were removed.
         $this->assertEquals(3, AuthorQuery::create()->count(), 'Correct records were removed from author table');
@@ -702,10 +686,6 @@ class BookstoreTest extends BookstoreEmptyTestBase
         PublisherQuery::create()->filterById($penguin_id)->delete();
         $vintage->delete();
 
-        // These have to be deleted manually also since we have onDelete
-        // set to SETNULL in the foreign keys in book. Is this correct?
-        $rowling->delete();
-        $scholastic->delete();
         $blc1->delete();
         $blc2->delete();
 

--- a/tests/Propel/Tests/Generator/Builder/Om/GeneratedQueryDoDeleteTest.php
+++ b/tests/Propel/Tests/Generator/Builder/Om/GeneratedQueryDoDeleteTest.php
@@ -82,13 +82,9 @@ class GeneratedQueryDoDeleteTest extends BookstoreEmptyTestBase
         // have to be in the criteria).
         $c->add(AuthorTableMap::COL_ID, $hp->getAuthorId());
         $c->add(PublisherTableMap::COL_ID, $hp->getPublisherId());
-        $c->setSingleRecord(true);
-        BookTableMap::doDelete($c);
 
-        // check to make sure the right # of records was removed
-        $this->assertCount(3, AuthorQuery::create()->find(), 'Expected 3 authors after deleting.');
-        $this->assertCount(3, PublisherQuery::create()->find(), 'Expected 3 publishers after deleting.');
-        $this->assertCount(3, BookQuery::create()->find(), 'Expected 3 books after deleting.');
+        $this->expectException(\Propel\Runtime\ActiveQuery\QueryExecutor\QueryExecutionException::class);
+        BookTableMap::doDelete($c);
     }
 
     /**

--- a/tests/Propel/Tests/Helpers/Bookstore/BookstoreTestBase.php
+++ b/tests/Propel/Tests/Helpers/Bookstore/BookstoreTestBase.php
@@ -62,6 +62,8 @@ abstract class BookstoreTestBase extends TestCaseFixturesDatabase
         if ($this->con !== null) {
             if ($this->con->isCommitable()) {
                 $this->con->commit();
+            } else {
+               $this->con->rollback();
             }
             $this->con = null;
         }

--- a/tests/Propel/Tests/Runtime/Util/TableMapExceptionsTest.php
+++ b/tests/Propel/Tests/Runtime/Util/TableMapExceptionsTest.php
@@ -69,9 +69,6 @@ class TableMapExceptionsTest extends BookstoreTestBase
      */
     public function testDoInsertExceptionsAreHandledCorrectly()
     {
-        if ($this->runningOnSQLite()) {
-            $this->markTestIncomplete('Can cause `General error: 5 database is locked` when DataFetcherInterface in formatter is not properly closed');
-        }
         $c = new Criteria();
         $c->setPrimaryTableName(BookTableMap::TABLE_NAME);
         $c->setUpdateValue(BookTableMap::COL_ID, 'lkhlkhj');

--- a/tests/Propel/Tests/Runtime/Util/TableMapTest.php
+++ b/tests/Propel/Tests/Runtime/Util/TableMapTest.php
@@ -350,9 +350,11 @@ class TableMapTest extends BookstoreTestBase
         $con = Propel::getServiceContainer()->getWriteConnection(BookTableMap::DATABASE_NAME);
         $count = $con->getQueryCount();
         $c = new Criteria(BookTableMap::DATABASE_NAME);
-        $c->add(BookTableMap::COL_TITLE, 'War And Peace');
-        $c->add(AuthorTableMap::COL_FIRST_NAME, 'Leo');
+        $c->addFilter(BookTableMap::COL_TITLE, 'War And Peace');
+        $c->addFilter(AuthorTableMap::COL_FIRST_NAME, 'Leo');
+        $this->expectException(\Propel\Runtime\ActiveQuery\QueryExecutor\QueryExecutionException::class);
         $c->doDelete($con);
+        /*
         $expectedSQL = $this->getSql("DELETE FROM author WHERE author.first_name='Leo'");
         $this->assertEquals($expectedSQL, $con->getLastExecutedQuery(), 'doDelete() issues two DELETE queries when passed conditions on two tables');
         $this->assertEquals($count + 2, $con->getQueryCount(), 'doDelete() issues two DELETE queries when passed conditions on two tables');
@@ -364,6 +366,7 @@ class TableMapTest extends BookstoreTestBase
         $expectedSQL = $this->getSql("DELETE FROM book WHERE book.title='War And Peace'");
         $this->assertEquals($expectedSQL, $con->getLastExecutedQuery(), 'doDelete() issues two DELETE queries when passed conditions on two tables');
         $this->assertEquals($count + 4, $con->getQueryCount(), 'doDelete() issues two DELETE queries when passed conditions on two tables');
+        */
     }
 
     /**

--- a/tests/Propel/Tests/TestCase.php
+++ b/tests/Propel/Tests/TestCase.php
@@ -207,5 +207,25 @@ class TestCase extends PHPUnitTestCase
         \Propel\Runtime\Propel::enableInstancePooling();
         
         parent::setUpBeforeClass();
+
+        //static::printFileNameOnStart();
+    }
+
+    /**
+     * Seems stupid, but incredible helpful on DB lock errors.
+     *
+     * @return void
+     */
+    public static function printFileNameOnStart(): void
+    {
+        $bt = debug_backtrace();
+        foreach($bt as $call) {
+            if (!isset($call['object'])) {
+                continue;
+            }
+            echo "\n doing " . $call['object']->getName() . "\n";
+            return;
+        }
+        var_dump($bt);
     }
 }


### PR DESCRIPTION
Propel Criteria allows to delete from multiple tables in the same Criteria:
```php
$c = new Criteria();
$c->add(BookTableMap::COL_ID, $hp->getId());
$c->add(AuthorTableMap::COL_ID, $hp->getAuthorId());
$c->add(PublisherTableMap::COL_ID, $hp->getPublisherId());
BookTableMap::doDelete($c);
```
This has several down-sides:
- creates inconsistent state when objects in pools are not cleared
- relies on resolving table names from filters, which is not 100% reliable
- like reusing the same variable multiple times with different types and meaning
- doesn't seem to be documented behavior

I see literally no upside to this.

This PR removes multi-table deletes.